### PR TITLE
Add variables to the --message CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,23 @@ $ tfc my_organization my_workspace foo=baz --message="Reticulating splines"
 Updated 'foo' from 'bar' to 'baz'
 Created run run-g6SmSsLVKg71yeNw - check status at: https://app.terraform.io/app/my_organization/workspaces/my_workspace/runs/run-g6SmSsLVKg71yeNw
 ```
+
+The message argument can contain variables which are expanded at runtime. These follow the same
+formatting rules as Python's `str.format(...)`. The variables which are currently defined are:
+
+- git_repository
+- git_branch
+- git_commit_subject
+- git_commit_author
+
+So for example:
+
+```
+$ tfc my_organization my_workspace foo=baz --message="{git_commit_subject} (author: {git_commit_author}, branch: {git_branch}, repo: {git_repository})"
+```
+
+might create a run with the message:
+
+```
+My commit message (author: Joe Bloggs, branch: my-branch, repo: terraform-cloud-client)
+```

--- a/src/tfc/message_variables.py
+++ b/src/tfc/message_variables.py
@@ -1,0 +1,38 @@
+import subprocess
+
+
+def message_variable(func):
+    """
+    Decorator which marks a function as being safe to use as a message variable.
+    """
+    func.is_message_variable = True
+    return func
+
+
+@message_variable
+def git_branch():
+    return subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True, encoding="utf8"
+    ).stdout.strip()
+
+
+@message_variable
+def git_commit_subject():
+    return subprocess.run(
+        ["git", "log", "-1", "--pretty=%s"], capture_output=True, encoding="utf8"
+    ).stdout.strip()
+
+
+@message_variable
+def git_commit_author():
+    return subprocess.run(
+        ["git", "log", "-1", "--pretty=%an"], capture_output=True, encoding="utf8"
+    ).stdout.strip()
+
+
+@message_variable
+def git_repository():
+    repository_url = subprocess.run(
+        ["git", "config", "--get", "remote.origin.url"], capture_output=True, encoding="utf8"
+    ).stdout.strip()
+    return repository_url.rpartition("/")[2].partition(".")[0]


### PR DESCRIPTION
The message argument can contain variables which are expanded at
runtime. These follow the same formatting rules as Python's
`str.format(...)`. The variables which are currently defined are:

- git_repository
- git_branch
- git_commit_subject
- git_commit_author